### PR TITLE
Make HookEnvironment instance of LazyDisposable

### DIFF
--- a/packages/hooks/source/HookEnvironment.ts
+++ b/packages/hooks/source/HookEnvironment.ts
@@ -10,7 +10,9 @@ export type HookEnv = { readonly hookEnvironment: HookEnvironment }
 
 export interface HookEnvironment extends LazyDisposable {
   readonly id: Uuid
-  readonly useRef: <A>(initialState?: InitialState<A>) => Effect<Pure<UseRef<A>>, UseRef<A>, any>
+  readonly useRef: <A>(
+    initialState?: InitialState<A | null | undefined | void>,
+  ) => Effect<Pure<UseRef<A>>, UseRef<A>, any>
   readonly useState: <A>(
     initialState: InitialState<A>,
   ) => Effect<Pure<UseState<A>>, UseState<A>, any>

--- a/packages/hooks/source/HookEnvironment.ts
+++ b/packages/hooks/source/HookEnvironment.ts
@@ -1,3 +1,4 @@
+import { LazyDisposable } from '@typed/disposable'
 import { Effect } from '@typed/effects'
 import { Pure } from '@typed/env'
 import { Arity1, IO } from '@typed/lambda'
@@ -5,7 +6,9 @@ import { Maybe } from '@typed/maybe'
 import { Uuid } from '@typed/uuid'
 import { Channel } from './Channel'
 
-export interface HookEnvironment {
+export type HookEnv = { readonly hookEnvironment: HookEnvironment }
+
+export interface HookEnvironment extends LazyDisposable {
   readonly id: Uuid
   readonly useRef: <A>(initialState?: InitialState<A>) => Effect<Pure<UseRef<A>>, UseRef<A>, any>
   readonly useState: <A>(

--- a/packages/hooks/source/HookEnvironment.ts
+++ b/packages/hooks/source/HookEnvironment.ts
@@ -28,7 +28,10 @@ export interface HookEnvironment extends LazyDisposable {
 
 export type InitialState<A> = A | IO<A>
 
-export type UseState<A> = readonly [IO<A>, (updateFn: Arity1<A, A>) => Effect<Pure<A>, A, any>]
+export type UseState<A> = readonly [
+  IO<Effect<Pure<A>, A, A>>,
+  (updateFn: Arity1<A, A>) => Effect<Pure<A>, A, any>,
+]
 
 export type UseRef<A> = readonly [Ref<A>, Arity1<A | undefined | void | null, void>]
 export type Ref<A> = { current: Maybe<A> }

--- a/packages/hooks/source/HookEnvironment.ts
+++ b/packages/hooks/source/HookEnvironment.ts
@@ -21,7 +21,7 @@ export interface HookEnvironment extends LazyDisposable {
     initial: InitialState<A>,
   ) => Effect<Pure<any>, (value: A) => Effect<Pure<any>, A, any>, any>
 
-  readonly resetId: Effect<Pure<any>, void, any>
+  readonly resetId: () => Effect<Pure<any>, void, any>
   readonly updated: boolean // true when useState has been updated
   readonly clearUpdated: () => Effect<Pure<any>, void, any>
 }

--- a/packages/hooks/source/WithHookEnvs.ts
+++ b/packages/hooks/source/WithHookEnvs.ts
@@ -1,7 +1,4 @@
 import { LazyEnv, Pure } from '@typed/env'
-import { HookEnvironment } from './HookEnvironment'
+import { HookEnv } from './HookEnvironment'
 
-export type WithHookEnvs<E> =
-  | LazyEnv<HookEnvironment, HookEnvironment>
-  | LazyEnv<E, any>
-  | Pure<any>
+export type WithHookEnvs<E> = LazyEnv<HookEnv, HookEnv> | LazyEnv<E, any> | Pure<any>

--- a/packages/hooks/source/createHookEnvironment.ts
+++ b/packages/hooks/source/createHookEnvironment.ts
@@ -20,7 +20,7 @@ export function createHookEnvironment(manager: HooksManager): HookEnvironment {
     useRef,
     useChannel,
     provideChannel,
-    resetId: Effect.fromEnv(Pure.fromIO(resetId)),
+    resetId: () => Effect.fromEnv(Pure.fromIO(resetId)),
     get updated() {
       return manager.hasBeenUpdated(hookEnvironment)
     },

--- a/packages/hooks/source/createHookEnvironment.ts
+++ b/packages/hooks/source/createHookEnvironment.ts
@@ -1,3 +1,4 @@
+import { Disposable } from '@typed/disposable'
 import { Effect } from '@typed/effects'
 import { Pure } from '@typed/env'
 import { Arity1, IO } from '@typed/lambda'
@@ -12,6 +13,7 @@ export function createHookEnvironment(manager: HooksManager): HookEnvironment {
   const id = uuid4(manager.uuidEnv.randomUuidSeed())
   const { nextId, resetId } = createIdGenerator()
   const hookStates = new Map<number, any>()
+  const disposable = Disposable.lazy()
   const hookEnvironment: HookEnvironment = {
     id,
     useState,
@@ -23,6 +25,7 @@ export function createHookEnvironment(manager: HooksManager): HookEnvironment {
       return manager.hasBeenUpdated(hookEnvironment)
     },
     clearUpdated: () => manager.setUpdated(hookEnvironment, false),
+    ...disposable,
   }
 
   return hookEnvironment

--- a/packages/hooks/source/createHookEnvironment.ts
+++ b/packages/hooks/source/createHookEnvironment.ts
@@ -20,7 +20,7 @@ export function createHookEnvironment(manager: HooksManager): HookEnvironment {
     useRef,
     useChannel,
     provideChannel,
-    resetId: () => Effect.fromEnv(Pure.fromIO(resetId)),
+    resetId,
     get updated() {
       return manager.hasBeenUpdated(hookEnvironment)
     },
@@ -54,7 +54,7 @@ export function createHookEnvironment(manager: HooksManager): HookEnvironment {
     return [getState, setState] as const
   }
 
-  function* useRef<A>(initial?: InitialState<A>) {
+  function* useRef<A>(initial?: InitialState<A | null | undefined | void>) {
     const id = nextId()
 
     if (!hookStates.has(id)) {
@@ -86,9 +86,12 @@ function getInitialValue<A>(initial: InitialState<A>) {
 function createIdGenerator() {
   let id = 0
   const nextId = () => ++id
-  const resetId = () => {
-    id = 0
-  }
+  const resetId = () =>
+    Effect.fromEnv(
+      Pure.fromIO(() => {
+        id = 0
+      }),
+    )
 
   return { nextId, resetId } as const
 }

--- a/packages/hooks/source/getHookEnv.ts
+++ b/packages/hooks/source/getHookEnv.ts
@@ -1,0 +1,8 @@
+import { get } from '@typed/effects'
+import { HookEnv } from './HookEnvironment'
+
+export function* getHookEnv() {
+  const { hookEnvironment } = yield* get<HookEnv>()
+
+  return hookEnvironment
+}

--- a/packages/hooks/source/provideChannel.ts
+++ b/packages/hooks/source/provideChannel.ts
@@ -1,8 +1,8 @@
-import { get } from '@typed/effects'
 import { fromJust, Just } from '@typed/maybe'
 import { Channel } from './Channel'
+import { getHookEnv } from './getHookEnv'
 import { HookEffects } from './HookEffects'
-import { HookEnvironment, InitialState } from './HookEnvironment'
+import { InitialState } from './HookEnvironment'
 import { useDepChange } from './useDepChange'
 import { useMemo } from './useMemo'
 
@@ -12,7 +12,7 @@ export function* provideChannel<A>(
   channel: Channel<A>,
   initial: InitialState<A>,
 ): HookEffects<never, readonly [A, UpdateChannel<A>]> {
-  const { useChannel, provideChannel, useRef } = yield* get<HookEnvironment>()
+  const { useChannel, provideChannel, useRef } = yield* getHookEnv()
   const [updateChannel, setUpdateChannel] = yield* useRef<UpdateChannel<A>>()
   const channelHasChanged = yield* useDepChange(channel)
   const currentValue = yield* useChannel(channel)

--- a/packages/hooks/source/runWithHooks.ts
+++ b/packages/hooks/source/runWithHooks.ts
@@ -4,6 +4,7 @@ import { HookEffects } from './HookEffects'
 import { HookEnvironment } from './HookEnvironment'
 import { withHooks } from './withHooks'
 
+// Run nested environments with their own hookEnvironment
 export function* runWithHooks<E, A>(
   effect: HookEffects<E, A>,
   hookEnvironment: HookEnvironment,

--- a/packages/hooks/source/runWithHooks.ts
+++ b/packages/hooks/source/runWithHooks.ts
@@ -2,10 +2,11 @@ import { runEffect } from '@typed/effects'
 import { Env, handle, Pure } from '@typed/env'
 import { HookEffects } from './HookEffects'
 import { HookEnvironment } from './HookEnvironment'
+import { withHooks } from './withHooks'
 
 export function* runWithHooks<E, A>(
   effect: HookEffects<E, A>,
-  hookEnv: HookEnvironment,
+  hookEnvironment: HookEnvironment,
 ): Generator<Env<E, A> | Pure<A>, A, A> {
-  return yield handle(hookEnv, runEffect(effect))
+  return yield handle({ hookEnvironment }, runEffect(withHooks(() => effect)()))
 }

--- a/packages/hooks/source/useChannel.test.ts
+++ b/packages/hooks/source/useChannel.test.ts
@@ -1,10 +1,10 @@
-import { runEffect, runEffects } from '@typed/effects'
-import { handle } from '@typed/env'
+import { runEffects } from '@typed/effects'
 import { describe, given, it } from '@typed/test'
 import { NodeGenerator } from '@typed/uuid'
 import { createChannel } from './createChannel'
 import { createHookEnvironment } from './createHookEnvironment'
 import { createHooksManager } from './createHooksManager'
+import { runWithHooks } from './runWithHooks'
 import { useChannel } from './useChannel'
 
 export const test = describe(`useChannel`, [
@@ -22,7 +22,7 @@ export const test = describe(`useChannel`, [
           const provide = yield* env.provideChannel(channel, value)
 
           equal(value, yield* provide(value))
-          equal(value, yield handle(env, runEffect(useChannel(channel))))
+          equal(value, yield* runWithHooks(useChannel(channel), env))
         }
       }
 

--- a/packages/hooks/source/useChannel.ts
+++ b/packages/hooks/source/useChannel.ts
@@ -1,12 +1,11 @@
-import { get } from '@typed/effects'
 import { Arity1 } from '@typed/lambda'
 import { Channel, ChannelValue } from './Channel'
+import { getHookEnv } from './getHookEnv'
 import { HookEffects } from './HookEffects'
-import { HookEnvironment } from './HookEnvironment'
 import { useMemo } from './useMemo'
 
 export function* useChannel<A>(channel: Channel<A>): HookEffects<never, A> {
-  const { useChannel } = yield* get<HookEnvironment>()
+  const { useChannel } = yield* getHookEnv()
 
   return yield* useChannel(channel)
 }

--- a/packages/hooks/source/useEffect.ts
+++ b/packages/hooks/source/useEffect.ts
@@ -1,6 +1,7 @@
 import { Disposable, dispose, disposeAll } from '@typed/disposable'
 import { Fn, IO } from '@typed/lambda'
 import { unwrap, withDefault } from '@typed/maybe'
+import { getHookEnv } from './getHookEnv'
 import { HookEffects } from './HookEffects'
 import { useDepChange } from './useDepChange'
 import { useTimer } from './useTimer'

--- a/packages/hooks/source/useMemo.ts
+++ b/packages/hooks/source/useMemo.ts
@@ -14,5 +14,5 @@ export function* useMemo<A extends readonly any[], B>(
     yield* setValue(() => fn(...deps))
   }
 
-  return getValue()
+  return yield* getValue()
 }

--- a/packages/hooks/source/useReducer.ts
+++ b/packages/hooks/source/useReducer.ts
@@ -7,7 +7,7 @@ import { useState } from './useState'
 export function* useReducer<A, B>(
   reducer: Arity2<A, B, A>,
   seed: A,
-): HookEffects<never, readonly [IO<A>, Arity1<B, Effects<never, A>>]> {
+): HookEffects<never, readonly [IO<Effects<never, A>>, Arity1<B, Effects<never, A>>]> {
   const [getState, updateState] = yield* useState(seed)
   const dispatch = yield* useMemo(
     reducer => (event: B) => updateState(state => reducer(state, event)),

--- a/packages/hooks/source/useRef.test.ts
+++ b/packages/hooks/source/useRef.test.ts
@@ -10,7 +10,7 @@ import { withHooks } from './withHooks'
 export const test = describe(`useRef`, [
   it(`allows keeping state across function invocations`, ({ equal }, done) => {
     const manager = createHooksManager(new NodeGenerator())
-    const hooksEnv = createHookEnvironment(manager)
+    const hookEnvironment = createHookEnvironment(manager)
     const initialValue: number = 1
     const endingValue: number = 100
     const test = withHooks(function*(value: number) {
@@ -28,7 +28,7 @@ export const test = describe(`useRef`, [
     })
 
     for (let i = initialValue; i <= endingValue; ++i) {
-      runEffects(test(i), hooksEnv)
+      runEffects(test(i), { hookEnvironment })
     }
   }),
 ])

--- a/packages/hooks/source/useRef.ts
+++ b/packages/hooks/source/useRef.ts
@@ -1,9 +1,9 @@
-import { get } from '@typed/effects'
+import { getHookEnv } from './getHookEnv'
 import { HookEffects } from './HookEffects'
-import { HookEnvironment, InitialState, UseRef } from './HookEnvironment'
+import { InitialState, UseRef } from './HookEnvironment'
 
 export function* useRef<A>(inititalState?: InitialState<A>): HookEffects<never, UseRef<A>> {
-  const { useRef } = yield* get<HookEnvironment>()
+  const { useRef } = yield* getHookEnv()
   const ref = yield* useRef(inititalState)
 
   return ref

--- a/packages/hooks/source/useRemoteData.ts
+++ b/packages/hooks/source/useRemoteData.ts
@@ -19,7 +19,7 @@ export type RemoteDataActions<A, B> = {
 
 export function* useRemoteData<A, B>(
   initial: InitialState<RemoteData<A, B>> = NoData,
-): HookEffects<never, readonly [IO<RemoteData<A, B>>, RemoteDataActions<A, B>]> {
+): HookEffects<never, readonly [IO<Effects<never, RemoteData<A, B>>>, RemoteDataActions<A, B>]> {
   const [getRemoteData, update] = yield* useState<RemoteData<A, B>>(initial)
   const set = (remoteData: RemoteData<A, B>) => update(() => remoteData)
   const actions = yield* useMemo(

--- a/packages/hooks/source/useState.test.ts
+++ b/packages/hooks/source/useState.test.ts
@@ -11,7 +11,7 @@ export const test = describe(`useState`, [
   given(`an initial state`, [
     it(`returns a current state and updater fn`, ({ equal }, done) => {
       const manager = createHooksManager(new NodeGenerator())
-      const hooksEnv = createHookEnvironment(manager)
+      const hookEnvironment = createHookEnvironment(manager)
       const expectedValues = [1, 2, 3]
       const test = withHooks(function*() {
         const [getX, updateX] = yield* useState(1)
@@ -30,9 +30,7 @@ export const test = describe(`useState`, [
         }
       })
 
-      do {
-        runEffects(test(), hooksEnv)
-      } while (hooksEnv.updated)
+      runEffects(test(), { hookEnvironment })
     }),
   ]),
 ])

--- a/packages/hooks/source/useState.test.ts
+++ b/packages/hooks/source/useState.test.ts
@@ -16,7 +16,7 @@ export const test = describe(`useState`, [
       const test = withHooks(function*() {
         const [getX, updateX] = yield* useState(1)
         const expected = expectedValues.shift()
-        const actual = getX()
+        const actual = yield* getX()
 
         if (!expected) {
           return done()

--- a/packages/hooks/source/useState.ts
+++ b/packages/hooks/source/useState.ts
@@ -1,11 +1,9 @@
-import { get } from '@typed/effects'
-import { HookEnvironment, InitialState, UseState } from './HookEnvironment'
-import { WithHookEnvs } from './WithHookEnvs'
+import { getHookEnv } from './getHookEnv'
+import { HookEffects } from './HookEffects'
+import { InitialState, UseState } from './HookEnvironment'
 
-export function* useState<A>(
-  inititalState: InitialState<A>,
-): Generator<WithHookEnvs<never>, UseState<A>, HookEnvironment> {
-  const { useState } = yield* get<HookEnvironment>()
+export function* useState<A>(inititalState: InitialState<A>): HookEffects<never, UseState<A>> {
+  const { useState } = yield* getHookEnv()
 
   return yield* useState(inititalState)
 }


### PR DESCRIPTION
Makes `HookEnvironment` an implementation of `LazyDisposable` to allow, mainly `useEffect`, to expose `Disposable`s that could otherwise be hidden. 

Breaking change: Creates `type HookEnv = { hookEnvironment: HookEnvionrment }` to allow using HookEnvironment identity in WeakMaps.