### PR TITLE
chore: implement new:package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean:cjs": "lerna exec rimraf cjs && tsc --build packages/tsconfig.cjs.json --clean",
     "clean:esm": "lerna exec rimraf esm && tsc --build packages/tsconfig.json --clean",
     "clean": " npm run clean:cjs && npm run clean:esm && lerna exec rimraf node_modules",
+    "new:package": "ts-node tools/new-package",
     "update:package": "ts-node tools/update-package-json",
     "update:tsconfig": "ts-node tools/update-tsconfig-json",
     "update:code-workspace": "ts-node tools/update-code-workspace",

--- a/packages/hooks/tsconfig.cjs.json
+++ b/packages/hooks/tsconfig.cjs.json
@@ -43,6 +43,9 @@
       "path": "../lambda/tsconfig.json"
     },
     {
+      "path": "../lenses/tsconfig.json"
+    },
+    {
       "path": "../logic/tsconfig.json"
     },
     {

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -43,6 +43,9 @@
       "path": "../lambda/tsconfig.json"
     },
     {
+      "path": "../lenses/tsconfig.json"
+    },
+    {
       "path": "../logic/tsconfig.json"
     },
     {

--- a/packages/lenses/tsconfig.cjs.json
+++ b/packages/lenses/tsconfig.cjs.json
@@ -16,5 +16,16 @@
     "./source/**/*.browser-test.ts",
     "./source/**/*.test.ts",
     "./umd/**"
+  ],
+  "references": [
+    {
+      "path": "../lambda/tsconfig.json"
+    },
+    {
+      "path": "../maybe/tsconfig.json"
+    },
+    {
+      "path": "../objects/tsconfig.json"
+    }
   ]
 }

--- a/packages/lenses/tsconfig.json
+++ b/packages/lenses/tsconfig.json
@@ -16,5 +16,16 @@
     "./source/**/*.browser-test.ts",
     "./source/**/*.test.ts",
     "./umd/**"
+  ],
+  "references": [
+    {
+      "path": "../lambda/tsconfig.json"
+    },
+    {
+      "path": "../maybe/tsconfig.json"
+    },
+    {
+      "path": "../objects/tsconfig.json"
+    }
   ]
 }

--- a/tools/common.ts
+++ b/tools/common.ts
@@ -3,8 +3,9 @@ import { join } from 'path'
 
 export const rootDirectory = join(__dirname, '..')
 export const sourceDirectory = join(rootDirectory, 'packages')
-export const PACKAGES = readdirSync(sourceDirectory).filter((x) => {
-  const pkg = join(sourceDirectory, x)
+export const getPackages = () =>
+  readdirSync(sourceDirectory).filter((x) => {
+    const pkg = join(sourceDirectory, x)
 
-  return statSync(pkg).isDirectory() && existsSync(join(pkg, 'package.json'))
-})
+    return statSync(pkg).isDirectory() && existsSync(join(pkg, 'package.json'))
+  })

--- a/tools/new-package.ts
+++ b/tools/new-package.ts
@@ -1,0 +1,126 @@
+import * as fs from 'fs'
+import { join } from 'path'
+import { createInterface } from 'readline'
+import { promisify } from 'util'
+import * as yargs from 'yargs'
+import { sourceDirectory } from './common'
+import { updateCodeWorkspace } from './update-code-workspace'
+import { updatePackageJson } from './update-package-json'
+import { updateRootConfigs, updateTsConfigForPkg } from './update-tsconfig-json'
+import { updateVsCodeSettings } from './update-vscode-settings'
+
+const options = yargs.boolean('force').alias('f', 'force').help().argv
+const { _: names, force = options.f } = options
+
+const mkdir = promisify(fs.mkdir)
+
+if (process.mainModule === module) {
+  ;(async () => {
+    for (const name of names) {
+      await newPackage(name)
+    }
+
+    updateRootConfigs()
+    updateCodeWorkspace()
+  })().catch((error) => {
+    console.error(error)
+
+    process.exit(1)
+  })
+}
+
+async function newPackage(name: string) {
+  const packageName = `@typed/${name}`
+  const packageDirectory = join(sourceDirectory, name)
+  const packageSourceDirectory = join(packageDirectory, 'source')
+  const packageJsonPath = join(packageDirectory, 'package.json')
+  const exists = fs.existsSync(packageJsonPath)
+
+  if (exists && force) {
+    deleteFolderRecursively(packageDirectory)
+  }
+
+  if (exists) {
+    return console.log(
+      `\n[${packageName}] :: Already Exists\n\nUse --force to recreate this package.\n`,
+    )
+  }
+
+  const description = await prompt(`\n[${packageName}] :: Please provide a description\n\n> `)
+  const keywords = (
+    await prompt(`\n[${packageName}] :: Please provide a comma-separated list of keywords\n\n> `)
+  )
+    .split(/\,/g)
+    .map((s) => s.trim())
+  // TODO: retrieve from git?
+  const author = await prompt(`\n[${packageName}] :: Please provide the author's information\n\n> `)
+
+  const packageJSONData = {
+    name: `${packageName}`,
+    version: '0.0.0',
+    description,
+    keywords,
+    author,
+  }
+
+  await shouldContinue(packageName, JSON.stringify(packageJSONData, null, 2))
+
+  // Create the stuff
+  await mkdir(packageDirectory)
+  await mkdir(packageSourceDirectory)
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJSONData))
+
+  await Promise.all([
+    updatePackageJson(name),
+    updateTsConfigForPkg(name),
+    updateVsCodeSettings(name),
+  ])
+}
+
+async function shouldContinue(name: string, data: string): Promise<void> {
+  console.log(`\nCreating ${name}:\n\n${data}\n\n`)
+  const answer = (await prompt('Would you like to continue? Y(es)/N(o)\n\n> ')).toLowerCase()
+
+  if (answer === 'yes' || answer === 'y') {
+    return
+  }
+
+  if (answer === 'no' || answer === 'n') {
+    console.log(`\n\nExiting.\n\n`)
+    process.exit(1)
+  }
+
+  return shouldContinue(name, data)
+}
+
+function prompt(q: string) {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise<string>((resolve) =>
+    rl.question(q, (a) => {
+      rl.close()
+      resolve(a)
+    }),
+  )
+}
+
+function deleteFolderRecursively(path: string) {
+  if (fs.existsSync(path)) {
+    fs.readdirSync(path).forEach((file) => {
+      const curPath = join(path, file)
+
+      if (fs.lstatSync(curPath).isDirectory()) {
+        // recurse
+        deleteFolderRecursively(curPath)
+      } else {
+        // delete file
+        fs.unlinkSync(curPath)
+      }
+    })
+    fs.rmdirSync(path)
+  }
+}

--- a/tools/update-code-workspace.ts
+++ b/tools/update-code-workspace.ts
@@ -1,33 +1,39 @@
 import { writeFileSync } from 'fs'
 import { EOL } from 'os'
 import { join } from 'path'
-import { PACKAGES, rootDirectory } from './common'
+import { getPackages, rootDirectory } from './common'
 
-const workspaceFile = join(rootDirectory, 'typed.code-workspace')
-const folders: { name: string; path: string }[] = [
-  ...PACKAGES.map((pkg) => {
-    return {
-      name: getPkgName(pkg),
-      path: `./packages/${pkg}`,
-    }
-  }),
-  { name: 'Typed Prelude', path: './' },
-]
-
-writeFileSync(workspaceFile, JSON.stringify({ folders }, null, 2) + EOL)
-
-function getPkgName(pkg: string) {
-  return capitalize(pkg.split('-').join(' '))
+if (process.mainModule === module) {
+  updateCodeWorkspace()
 }
 
-function capitalize(str: string): string {
-  return capitalizeFirst(str.split(' ').map(capitalizeFirst).join(' '))
-}
+export function updateCodeWorkspace() {
+  const workspaceFile = join(rootDirectory, 'typed.code-workspace')
+  const folders: { name: string; path: string }[] = [
+    ...getPackages().map((pkg) => {
+      return {
+        name: getPkgName(pkg),
+        path: `./packages/${pkg}`,
+      }
+    }),
+    { name: 'Typed Prelude', path: './' },
+  ]
 
-function capitalizeFirst(str: string): string {
-  if (str && str[0]) {
-    return str[0].toUpperCase() + str.slice(1)
+  writeFileSync(workspaceFile, JSON.stringify({ folders }, null, 2) + EOL)
+
+  function getPkgName(pkg: string) {
+    return capitalize(pkg.split('-').join(' '))
   }
 
-  return str
+  function capitalize(str: string): string {
+    return capitalizeFirst(str.split(' ').map(capitalizeFirst).join(' '))
+  }
+
+  function capitalizeFirst(str: string): string {
+    if (str && str[0]) {
+      return str[0].toUpperCase() + str.slice(1)
+    }
+
+    return str
+  }
 }

--- a/tools/update-package-json.ts
+++ b/tools/update-package-json.ts
@@ -1,9 +1,15 @@
 import * as fs from 'fs'
 import { EOL } from 'os'
 import * as path from 'path'
-import { PACKAGES, sourceDirectory } from './common'
+import { getPackages, sourceDirectory } from './common'
 
-for (const pkg of PACKAGES) {
+if (process.mainModule === module) {
+  for (const pkg of getPackages()) {
+    updatePackageJson(pkg)
+  }
+}
+
+export function updatePackageJson(pkg: string) {
   const pkgDirectory = path.join(sourceDirectory, pkg)
   const packageJSONPath = path.join(pkgDirectory, 'package.json')
 

--- a/tools/update-tsconfig-json.ts
+++ b/tools/update-tsconfig-json.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import { EOL } from 'os'
 import * as path from 'path'
-import { PACKAGES, sourceDirectory } from './common'
+import { getPackages, sourceDirectory } from './common'
 
 const FILES_TO_EXCLUDE = [
   './source/**/*.test.ts',
@@ -11,15 +11,21 @@ const FILES_TO_EXCLUDE = [
   './umd/**',
 ]
 
-updateRootConfig('tsconfig.json')
-updateRootConfig('tsconfig.cjs.json')
+if (process.mainModule === module) {
+  updateRootConfigs()
 
-PACKAGES.forEach(updatePackage)
+  getPackages().forEach(updateTsConfigForPkg)
+}
 
-function updateRootConfig(configName: string) {
+export function updateRootConfigs() {
+  updateRootConfig('tsconfig.json')
+  updateRootConfig('tsconfig.cjs.json')
+}
+
+export function updateRootConfig(configName: string) {
   const rootTsConfigPath = path.join(sourceDirectory, configName)
   const rootTsConfig = getOrCreateJsonFile(rootTsConfigPath)
-  const packagePaths = PACKAGES.map((pkg) => `./${pkg}/${configName}`)
+  const packagePaths = getPackages().map((pkg) => `./${pkg}/${configName}`)
 
   rootTsConfig.references = packagePaths.map((path) => ({ path }))
   rootTsConfig.files = []
@@ -29,7 +35,7 @@ function updateRootConfig(configName: string) {
   fs.writeFileSync(rootTsConfigPath, JSON.stringify(rootTsConfig, null, '  ') + EOL)
 }
 
-function updatePackage(pkg: string) {
+export function updateTsConfigForPkg(pkg: string) {
   const pkgDirectory = path.join(sourceDirectory, pkg)
   const packageJSONPath = path.join(pkgDirectory, 'package.json')
 

--- a/tools/update-vscode-settings.ts
+++ b/tools/update-vscode-settings.ts
@@ -1,10 +1,14 @@
 import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
-import { PACKAGES, sourceDirectory } from './common'
+import { getPackages, sourceDirectory } from './common'
 
 const VSCODE_SOURCE_FOLDER = join(__dirname, 'vscode-packages')
 
-PACKAGES.forEach((pkg) => {
+if (process.mainModule === module) {
+  getPackages().forEach(updateVsCodeSettings)
+}
+
+export function updateVsCodeSettings(pkg: string) {
   const pkgDirectory = join(sourceDirectory, pkg)
   const vscodeDirectory = join(pkgDirectory, '.vscode')
 
@@ -13,7 +17,7 @@ PACKAGES.forEach((pkg) => {
   }
 
   copyFilesRecursively(VSCODE_SOURCE_FOLDER, vscodeDirectory)
-})
+}
 
 function copyFilesRecursively(sourceFolder: string, destinationFolder: string) {
   for (const pathPart of readdirSync(sourceFolder)) {


### PR DESCRIPTION
Add a simplified way of getting set up with a new package.

`npm run new:package pkg1 pkg2 ...`